### PR TITLE
노션과 슬랙 api 연결

### DIFF
--- a/app/agents/tools/notion_tool.py
+++ b/app/agents/tools/notion_tool.py
@@ -10,18 +10,20 @@ def create_notion_tools(user_id: str):
 
     def get_notion_headers():
         """Notion API 헤더 생성"""
-        token_info = get_service_token(user_id, "notion")
+        from app.utils.db import get_service_token_enhanced
+        
+        token_info = get_service_token_enhanced(user_id, "notion")
         print(f"🔍 노션 토큰 정보: {token_info}")
 
         if not token_info:
             raise Exception(
-                "Notion 토큰이 없습니다. .env 파일에 NOTION_TOKEN을 설정해주세요."
+                "Notion 토큰이 없습니다. 직원 DB에 NOTION_API를 설정하거나 .env 파일에 NOTION_TOKEN을 설정해주세요."
             )
 
         token = token_info.get("token")
         if not token:
             raise Exception(
-                "Notion 토큰이 없습니다. .env 파일에 NOTION_TOKEN을 설정해주세요."
+                "Notion 토큰이 없습니다. 직원 DB에 NOTION_API를 설정하거나 .env 파일에 NOTION_TOKEN을 설정해주세요."
             )
 
         print(f"🔑 노션 토큰 (앞 10자): {token[:10]}...")

--- a/app/agents/tools/slack_tool.py
+++ b/app/agents/tools/slack_tool.py
@@ -10,13 +10,15 @@ def create_slack_tools(user_id: str):
 
     def get_slack_headers():
         """Slack API 헤더 생성"""
-        token_info = get_service_token(user_id, "slack")
+        from app.utils.db import get_service_token_enhanced
+        
+        token_info = get_service_token_enhanced(user_id, "slack")
         if not token_info:
-            raise Exception("Slack 토큰이 없습니다")
+            raise Exception("Slack 토큰이 없습니다. 직원 DB에 SLACK_API를 설정하거나 .env 파일에 SLACK_USER_TOKEN을 설정해주세요.")
 
         user_token = token_info.get("user_token")
         if not user_token:
-            raise Exception("Slack User 토큰이 없습니다")
+            raise Exception("Slack User 토큰이 없습니다. 직원 DB에 SLACK_API를 설정하거나 .env 파일에 SLACK_USER_TOKEN을 설정해주세요.")
 
         return {
             "Authorization": f"Bearer {user_token}",

--- a/app/features/employee_google/models.py
+++ b/app/features/employee_google/models.py
@@ -1,5 +1,5 @@
 # models.py
-# SQLAlchemy ORM 모델을 정의하여 데이터베이스 테이블과 파이썬 클래스를 매핑합니다.
+# SQLAlchemy ORM 모델을 정의하여 데이터베이스 테이블과 파이썬 클래스를 매핑합니다. 
 
 from sqlalchemy import Column, Integer, String, LargeBinary, ForeignKey
 from sqlalchemy.orm import relationship

--- a/app/main.py
+++ b/app/main.py
@@ -175,14 +175,13 @@ async def google_login():
 
 @app.get("/auth/google/callback")
 async def google_callback(
-    code: str = None, user_id: str = "user_123", error: str = None, state: str = None
+    code: str = None, error: str = None, state: str = None
 ):
     """Google OAuth 콜백 처리"""
     print(f"📥 콜백 수신:")
     print(f"   Code: {code[:20] + '...' if code else 'None'}")
     print(f"   Error: {error}")
     print(f"   State: {state}")
-    print(f"   User ID: {user_id}")
 
     if not CLIENT_ID:
         raise HTTPException(
@@ -224,10 +223,30 @@ async def google_callback(
             raise HTTPException(status_code=400, detail=f"토큰 교환 실패: {resp.text}")
 
         tokens = resp.json()
-        print(f"✅ 토큰 교환 성공: {user_id}")
+        access_token = tokens.get("access_token")
+        
+        # 액세스 토큰으로 Google 사용자 정보 가져오기
+        print(f"🔄 Google 사용자 정보 요청")
+        user_info_resp = requests.get(
+            f"https://www.googleapis.com/oauth2/v1/userinfo?access_token={access_token}"
+        )
+        
+        if user_info_resp.status_code != 200:
+            print(f"❌ 사용자 정보 조회 실패: {user_info_resp.status_code} - {user_info_resp.text}")
+            raise HTTPException(status_code=400, detail=f"사용자 정보 조회 실패: {user_info_resp.text}")
+        
+        user_info = user_info_resp.json()
+        google_user_id = user_info.get("id")  # Google User ID
+        user_name = user_info.get("name", "Unknown")
+        user_email = user_info.get("email", "Unknown")
+        
+        if not google_user_id:
+            raise HTTPException(status_code=400, detail="Google 사용자 ID를 가져올 수 없습니다.")
+        
+        print(f"✅ 토큰 교환 성공 - Google User ID: {google_user_id}, Name: {user_name}, Email: {user_email}")
 
-        # 토큰 저장 (DB와 pickle 파일 모두)
-        save_user_tokens(user_id, "google", tokens)
+        # 토큰 저장 (DB와 pickle 파일 모두) - 이제 실제 google_user_id 사용
+        save_user_tokens(google_user_id, "google", tokens)
 
         # Google API 클라이언트에서 사용할 수 있도록 pickle 파일로도 저장
         import pickle
@@ -253,8 +272,11 @@ async def google_callback(
 
         return {
             "status": "success",
-            "message": f"Google 인증이 완료되었습니다. 사용자 ID: {user_id}",
-            "user_id": user_id,
+            "message": f"Google 인증이 완료되었습니다. 사용자: {user_name} ({user_email})",
+            "user_id": google_user_id,
+            "google_user_id": google_user_id,
+            "user_name": user_name,
+            "user_email": user_email,
             "tokens_saved": True,
         }
 

--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -53,3 +53,97 @@ def save_user_tokens(user_id: str, service: str, tokens: dict):
 def get_service_token(user_id: str, service: str) -> dict:
     """특정 서비스의 토큰 조회"""
     return user_tokens.get(user_id, {}).get(service, {})
+
+
+def get_user_api_tokens_from_db(google_user_id: str) -> dict:
+    """
+    데이터베이스에서 사용자별 API 토큰을 조회합니다.
+    google_user_id로 조회하여 notion_api와 slack_api를 반환합니다.
+    """
+    from app.features.employee_google.crud import get_employee_by_google_id
+    from app.utils.crypto_utils import decrypt_data
+    
+    print(f"🔍 DB에서 토큰 조회 시작 - Google User ID: {google_user_id}")
+    
+    db = SessionLocal()
+    try:
+        employee = get_employee_by_google_id(db, google_user_id)
+        if not employee:
+            print(f"❌ 사용자를 찾을 수 없습니다 - Google User ID: {google_user_id}")
+            return {}
+        
+        print(f"✅ 사용자 찾음 - ID: {employee.id}, 이름: {employee.full_name}, 이메일: {employee.email}")    
+        print(f"🔍 Notion API 필드 존재 여부: {employee.notion_api is not None}")
+        print(f"🔍 Slack API 필드 존재 여부: {employee.slack_api is not None}")
+            
+        tokens = {}
+        
+        # Notion API 토큰 복호화
+        if employee.notion_api:
+            try:
+                print(f"🔓 Notion 토큰 복호화 시도 중...")
+                notion_token = decrypt_data(employee.notion_api, "string")
+                tokens["notion"] = {"token": notion_token}
+                print(f"✅ Notion 토큰 복호화 성공 - 토큰 길이: {len(notion_token)}")
+            except Exception as e:
+                print(f"❌ Notion 토큰 복호화 실패: {e}")
+        else:
+            print("❌ Notion API 토큰이 데이터베이스에 저장되어 있지 않습니다.")
+        
+        # Slack API 토큰 복호화  
+        if employee.slack_api:
+            try:
+                print(f"🔓 Slack 토큰 복호화 시도 중...")
+                slack_token = decrypt_data(employee.slack_api, "string")
+                tokens["slack"] = {"user_token": slack_token}
+                print(f"✅ Slack 토큰 복호화 성공 - 토큰 길이: {len(slack_token)}")
+            except Exception as e:
+                print(f"❌ Slack 토큰 복호화 실패: {e}")
+        else:
+            print("❌ Slack API 토큰이 데이터베이스에 저장되어 있지 않습니다.")
+        
+        print(f"🎯 최종 반환 토큰: {list(tokens.keys())}")
+        return tokens
+        
+    finally:
+        db.close()
+
+
+def get_service_token_enhanced(user_id: str, service: str) -> dict:
+    """
+    특정 서비스의 토큰 조회 (DB에서 사용자별 토큰 우선 조회)
+    1. 먼저 DB에서 google_user_id로 사용자별 토큰 조회
+    2. 없으면 기존 메모리 저장소에서 조회
+    3. 그것도 없으면 env_tokens에서 기본값 조회
+    """
+    print(f"🔍 get_service_token_enhanced 호출 - User ID: {user_id}, Service: {service}")
+    
+    # 1. DB에서 사용자별 토큰 조회
+    db_tokens = get_user_api_tokens_from_db(user_id)
+    print(f"🔍 DB에서 조회된 토큰들: {list(db_tokens.keys())}")
+    
+    if service in db_tokens:
+        print(f"✅ DB에서 {service} 토큰 찾음")
+        return db_tokens[service]
+    else:
+        print(f"❌ DB에서 {service} 토큰을 찾을 수 없음")
+    
+    # # 2. 기존 메모리 저장소에서 조회 (잘 되면 삭제 해도 무방)
+    # from app.utils.env_loader import env_tokens
+    # user_service_token = user_tokens.get(user_id, {}).get(service)
+    # if user_service_token:
+    #     print(f"✅ 메모리에서 {service} 토큰 찾음")
+    #     return user_service_token
+    # else:
+    #     print(f"❌ 메모리에서 {service} 토큰을 찾을 수 없음")
+        
+    # # 3. env_tokens에서 기본값 조회
+    # env_token = env_tokens.get(service, {})
+    # if env_token:
+    #     print(f"✅ 환경변수에서 {service} 토큰 찾음")
+    #     return env_token
+    # else:
+    #     print(f"❌ 환경변수에서 {service} 토큰을 찾을 수 없음")
+        
+    # print(f"❌ 모든 소스에서 {service} 토큰을 찾을 수 없음")
+    # return {}


### PR DESCRIPTION
Caesar_Backend_v2/app/agents/tools/slack_tool.py Caesar_Backend_v2/app/agents/tools/notion_tool.py Caesar_Backend_v2/app/utils/db.py Caesar_Backend_v2/app/main.py
	•	사용자 이름을 가져오는 걸 google_user_id를 가져오게 변경.
	•	slack과 notion의 api를 env_loader를 거치지 않고 db 파일의 함수를 통해 바로 가져오게 끔 변경
	•	채팅에서 잘 작동하고 api키를 변경해도 잘 된다. 지금까지는